### PR TITLE
Updated the R in DESCRIPTION and travis.yml files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
 language: r
+r:
+- release
+- oldrel
+- 3.3.3
+- 3.3.2
+- 3.3.1
+- 3.3.0
 sudo: required
 cache: packages
 warnings_are_errors: false

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Authors@R: c(
 biocViews: Clustering, Metagenomics, Microbiome, Sequencing,SystemsBiology,ImmunoOncology
 License: BSD_2_clause + file LICENSE
 Depends:
-    R (>= 3.5.0),
+    R (>= 3.3.0),
     phyloseq,
     ggplot2
 Imports:


### PR DESCRIPTION
Travis CI now builds for various versions of R:
```yaml
 r:
 - release
 - oldrel
 - 3.3.3
 - 3.3.2
 - 3.3.1
 - 3.3.0
```

The package now depends on R >= 3.3.0:
```yaml
 Depends:
    R (>= 3.3.0),
```