### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ microbiome R package
 
 Tools for the exploration and analysis of microbiome profiling data sets, in particular large-scale population studies and 16S taxonomic profiling. 
 
-This R package extends the phyloseq data container; for related recent work with (Tree)SummarizedExperiment containers, see [microbiome.github.io](microbiome.github.io)
+This R package extends the phyloseq data container; for related recent work with (Tree)SummarizedExperiment containers, see [microbiome.github.io](https://microbiome.github.io/)
 
 ### Installation and use
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ microbiome R package
 
 Tools for the exploration and analysis of microbiome profiling data sets, in particular large-scale population studies and 16S taxonomic profiling. 
 
-This R package extends the phyloseq data container; for related recent work with (Tree)SummarizedExperiment containers, see [microbiome.github.io](https://microbiome.github.io/)
+This R package extends the phyloseq data container; for related recent work with (Tree)SummarizedExperiment containers, see [https://microbiome.github.io/](https://microbiome.github.io/).
 
 ### Installation and use
 


### PR DESCRIPTION
Link clicked on through GitHub went to link relative to GitHub.