### PR TITLE
adding group info for averaged data

### DIFF
--- a/R/plot_composition.R
+++ b/R/plot_composition.R
@@ -134,9 +134,14 @@ plot_composition <- function(x,
     dfm$Tax <- factor(dfm$Tax, levels=otu.sort)
 
     if (!is.null(group_by)) {
-    dfm$Group <- meta(x)[[group_by]][match(as.character(dfm$Sample),
-        sample_names(x))]
-    }
+    	if (!is.null(average_by)) {
+      		dfm$Group <- meta(x)[[group_by]][match(as.character(dfm$Sample),
+                                             meta(x)[[average_by]])]
+    	}else{
+	    	dfm$Group <- meta(x)[[group_by]][match(as.character(dfm$Sample),
+        				sample_names(x))]
+    	}
+	  }
 
     # SampleIDs for plotting
     if (x.label %in% colnames(sample_data(x)) & is.null(average_by)) {


### PR DESCRIPTION
Hi,

I was trying to use both `average_by` and `group_by` options in the `plot_composition()` function and noticed that my `group_by` info was ignored. It appears to me that after averaging, the current sample names `dfm$Sample` do not match with the original sample names `sample_names(x)` anymore. Therefore `match(as.character(dfm$Sample), sample_names(x))` returns a list of NAs. Therefore I'm proposing this quick fix. It works on my data/machine. Please consider.

Best,
Huan