### PR TITLE
added sep argument in read_biom2phyloseq.R

### DIFF
--- a/R/read_biom2phyloseq.R
+++ b/R/read_biom2phyloseq.R
@@ -7,6 +7,8 @@
 #' @param taxonomy.file NULL the latest version has taxonomic information
 #' within the biom 
 #' @param metadata.file A simple metadata/mapping file with .csv extension
+#' @param sep Separator of the metadata file in case it isn't comma-delimited.
+#' Default is ","
 #' @param ... Arguments to pass for import_biom
 #' @return  \code{\link{phyloseq-class}} object.
 #' @export

--- a/R/read_biom2phyloseq.R
+++ b/R/read_biom2phyloseq.R
@@ -20,7 +20,7 @@
 #' @author Sudarshan A. Shetty \email{sudarshanshetty9@@gmail.com}
 #' @keywords utilities
 read_biom2phyloseq <- function(biom.file = NULL, 
-                            taxonomy.file = NULL, metadata.file = NULL, ...)
+                            taxonomy.file = NULL, metadata.file = NULL, sep = ",", ...)
 {
 
     if (is.null(biom.file)) {return(NULL)}
@@ -34,7 +34,7 @@ read_biom2phyloseq <- function(biom.file = NULL,
 
     if (!is.null(metadata.file)) {
         map <- read.csv(metadata.file, 
-                check.names = FALSE, row.names = 1)
+                check.names = FALSE, row.names = 1, sep = sep)
         s.map <- sample_data(map)
         phyobj <- merge_phyloseq(otu_biom, 
                         s.map)

--- a/man/read_biom2phyloseq.Rd
+++ b/man/read_biom2phyloseq.Rd
@@ -8,6 +8,7 @@ read_biom2phyloseq(
   biom.file = NULL,
   taxonomy.file = NULL,
   metadata.file = NULL,
+  sep = ",",
   ...
 )
 }
@@ -18,6 +19,9 @@ read_biom2phyloseq(
 within the biom}
 
 \item{metadata.file}{A simple metadata/mapping file with .csv extension}
+
+\item{sep}{Separator of the metadata file in case it isn't comma-delimited.
+Default is ","}
 
 \item{...}{Arguments to pass for import_biom}
 }


### PR DESCRIPTION
This only applies for meta-data as separator is irrelevant for BIOM files. Default sep for read.csv is (of course) ",".