### PR TITLE
Fix: taxa naming in merge_taxa2, see issue 223

### DIFF
--- a/R/merge_taxa.R
+++ b/R/merge_taxa.R
@@ -49,7 +49,7 @@ merge_taxa2 <- function(x, taxa = NULL, pattern = NULL, name = "Merged") {
 
     mytaxa <- gsub("\\)", "\\\\)", gsub("\\(", "\\\\(", mytaxa))
     taxa_names(x2) <- gsub(mytaxa[[1]], name, taxa_names(x2))
-    tax_table(x2)[nrow(tax_table(x2)),] <- rep(name, ncol(tax_table(x2)))
+    tax_table(x2)[1,] <- rep(name, ncol(tax_table(x2)))
     
     x2
     


### PR DESCRIPTION
function merge_taxa2 was creating NA annotations for the merged taxon on all taxonomic ranks. See https://github.com/microbiome/microbiome/issues/223