### PR TITLE
Quick fix for rclr transformation 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: Microbiome Analytics
 Description: Utilities for microbiome analysis.
 Encoding: UTF-8
-Version: 1.31.2
+Version: 1.31.3
 Date: 2025-07-17
 Authors@R: c(
     person("Leo", "Lahti", email = "leo.lahti@iki.fi",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,9 @@ Authors@R: c(
              role = c("aut", "cre"),
 	     comment = c(ORCID = "0000-0001-5537-637X")),
     person("Sudarshan", "Shetty", role = "aut",
-         comment = c(ORCID = "0000-0001-7280-9915")))
+         comment = c(ORCID = "0000-0001-7280-9915")),
+    person("Rasmus", "Hindström", role = "ctb",
+         comment = c(ORCID = "0009-0004-5731-178X")))
 biocViews: Metagenomics,Microbiome,Sequencing,SystemsBiology
 License: BSD_2_clause + file LICENSE
 Depends:

--- a/R/transform.R
+++ b/R/transform.R
@@ -181,7 +181,13 @@ transform <- function(x, transform = "identity", target = "OTU",
         
     } else if (transform == "scale") {
         
-        xt <- scale * x 
+        xt <- scale * x
+
+    } else if (transform == "rclr") {
+	
+	xt <- decostand(x, method = "rclr", MARGIN = 2)
+	dimnames(xt) <- dimnames(x)
+	
         
     } else {
         

--- a/R/transform.R
+++ b/R/transform.R
@@ -3,7 +3,7 @@
 #' @param x \code{\link{phyloseq-class}} object
 #' @param transform Transformation to apply. The options include:
 #' 'compositional' (ie relative abundance), 'Z', 'log10', 'log10p',
-#' 'hellinger', 'identity', 'clr', 'alr', or any method from the
+#' 'hellinger', 'identity', 'clr', 'alr', 'rclr' or any method from the
 #' vegan::decostand function.
 #' @param target Apply the transform for 'sample' or 'OTU'.
 #' Does not affect the log transform.
@@ -184,10 +184,9 @@ transform <- function(x, transform = "identity", target = "OTU",
         xt <- scale * x
 
     } else if (transform == "rclr") {
-	
-	xt <- decostand(x, method = "rclr", MARGIN = 2)
-	dimnames(xt) <- dimnames(x)
-	
+        
+        xt <- decostand(x, method = "rclr", MARGIN = 2)
+        dimnames(xt) <- dimnames(x)
         
     } else {
         

--- a/man/abundances.Rd
+++ b/man/abundances.Rd
@@ -13,7 +13,7 @@ abundances(x, transform = "identity")
 
 \item{transform}{Transformation to apply. The options include:
 'compositional' (ie relative abundance), 'Z', 'log10', 'log10p',
-'hellinger', 'identity', 'clr', 'alr', or any method from the
+'hellinger', 'identity', 'clr', 'alr', 'rclr' or any method from the
 vegan::decostand function.}
 }
 \value{

--- a/man/transform.Rd
+++ b/man/transform.Rd
@@ -20,7 +20,7 @@ transform(
 
 \item{transform}{Transformation to apply. The options include:
 'compositional' (ie relative abundance), 'Z', 'log10', 'log10p',
-'hellinger', 'identity', 'clr', 'alr', or any method from the
+'hellinger', 'identity', 'clr', 'alr', 'rclr' or any method from the
 vegan::decostand function.}
 
 \item{target}{Apply the transform for 'sample' or 'OTU'.


### PR DESCRIPTION
Apply correct dimnames after rclr transformation with decostand to fix issue
with invalid phyloseq object.